### PR TITLE
7 Head Title looks Squashed on Mobile Screens

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,20 +1,12 @@
 <header>
-  <ngb-carousel [showNavigationArrows]="showNavigationArrows" [showNavigationIndicators]="showNavigationIndicators">
-    <ng-template *ngFor="let image of images" ngbSlide>
-      <div class="picsum-img-wrapper">
-        <img [src]="image" alt="Random slide"
-             style="width: 100%; height: 750px; object-fit: cover; object-position: 40%">
-      </div>
-      <div class="carousel-caption text-alt background-lightAlpha rounded">
-        <img src="assets/icons/Waikato%20Crest.png" width="100">
-        <h1 class="text-header">Waikato Navy Cadets</h1>
-      </div>
-    </ng-template>
-  </ngb-carousel>
-
-  <div class=" text-alt background-banner">
-
+  <div class="headContainer">
+    <img class="headImage" src="assets/images/bannerImage.png">
+    <div class="centered background-lightAlpha text-alt rounded">
+      <img src="assets/icons/Waikato%20Crest.png" width="100">
+      <h1 class="text-header">Waikato Navy Cadets</h1>
+    </div>
   </div>
+
   <nav class="navbar navbar-expand-lg navbar-dark background-alt text-medium text-light">
     <div class="container">
       <button (click)="isMenuCollapsed = !isMenuCollapsed" aria-controls="navbarSupportedContent" aria-expanded="false"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,3 +11,28 @@
 .a-light-color {
   color: $background-light;
 }
+
+.headImage{
+  width: 100%;
+  height: 750px;
+  object-fit: cover;
+  object-position: 40%
+}
+
+.headContainer {
+  position: relative;
+  text-align: center;
+  color: $background-light;
+}
+
+.centered {
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  width: 80%;
+  position: absolute;
+  top: 55%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
Because
- Used a carousal which was never utilized so in this change it was replaced with a much simpler method
- Fix the title being off screen, and also remove the squashed title look on the edges on mobile phones